### PR TITLE
Extract key type using type traits

### DIFF
--- a/RadixSort/Makefile
+++ b/RadixSort/Makefile
@@ -42,10 +42,10 @@ COMMON = common_sort.h regionsSort.h parallel.h prefixsum.h radix_configs.h sequ
 default : radixSort radixSort_cycle 
 
 radixSort : $(COMMON)
-	g++ -I. -std=c++14 example.cpp -DCILKP -DBITS_HACK -O3 -flto -march=native -fcilkplus -lcilkrts -o radixSort
+	g++ -I. -std=c++14 example.cpp -DCILKP -DBITS_HACK -DLONG_ARRAY -O3 -flto -march=native -fcilkplus -lcilkrts -o radixSort
 
 radixSort_cycle : $(COMMON)
-	g++ -I. -std=c++14 example.cpp -DCILKP -DCYCLE -DBITS_HACK -O3 -flto -march=native -fcilkplus -lcilkrts -o radixSort_cycle
+	g++ -I. -std=c++14 example.cpp -DCILKP -DCYCLE -DBITS_HACK -DLONG_ARRAY -O3 -flto -march=native -fcilkplus -lcilkrts -o radixSort_cycle
 
 # Each C source file will have a corresponding file of prerequisites.
 # Include the prerequisites for each of our C source files.

--- a/RadixSort/radixSort.h
+++ b/RadixSort/radixSort.h
@@ -27,6 +27,7 @@
 
 //#define DEBUG 0
 
+#include <type_traits>
 #include <iostream>
 #include <algorithm>
 #include <cmath>
@@ -171,8 +172,9 @@ template <class E, class F, class K>
 }
 template <class T, class F>
   static void parallelIntegerSort(T *A, sizeT n, F f) {
-  T temp;
-  T maxV = findMax(A, n, f, temp);
+  using key_type = std::remove_reference_t<std::result_of_t<F(T)>>;
+  key_type temp;
+  key_type maxV = findMax(A, n, f, temp);
   iSort(A, n, maxV+1,  f); 
 }
 


### PR DESCRIPTION
Use return type of key extractor function to get the key type. This allows you to sort any input type with a single interface function.